### PR TITLE
client side parameter validation & toasts for login and register

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12813,6 +12813,14 @@
         }
       }
     },
+    "react-toasts": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/react-toasts/-/react-toasts-3.0.6.tgz",
+      "integrity": "sha512-SgtyyytTG6wcjI4rgv4OZmHHLiETYfiHfyz1qLv8Cxu6h9I3p+asUgY3L5DSEorOBSS4Dtv87xwXhi0KsCgLvQ==",
+      "requires": {
+        "watchable-stores": "^2.0.2"
+      }
+    },
     "react-transition-group": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
@@ -15493,6 +15501,11 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "watchable-stores": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/watchable-stores/-/watchable-stores-2.0.2.tgz",
+      "integrity": "sha512-xKzypK+hG6gaZFcmiEvdazbD9Z8+hIlr+frC7Ne4N4LI0zvuPaT5uPrhn2RMxhiwaLVw70rctes+rPUTvwhPNg=="
     },
     "watchpack": {
       "version": "1.7.5",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-toasts": "^3.0.6",
     "sass": "^1.42.1",
     "web-vitals": "^1.1.2"
   },

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -4,6 +4,7 @@ import Button from "react-bootstrap/Button";
 import { Link, useHistory } from "react-router-dom";
 import "./login.scss";
 import axios from "axios";
+import { ToastsContainer, ToastsContainerPosition, ToastsStore } from "react-toasts";
 
 
 export default function Login() {
@@ -12,23 +13,30 @@ export default function Login() {
 	const history = useHistory();
 
 	const login = () => {
+		if (email === "") {
+			ToastsStore.error("Please provide an email");
+			return;
+		} else if (pwd === "") {
+			ToastsStore.error("Please provide an password");
+			return;
+		}
+
 		const data = {
 			email: email,
 			password: pwd
 		};
+
 		axios.post("/account/login", data)
 			.then((res) => {
-				// TODO: Transition to landing page
-				console.log(res);
 				history.push("/home");
 			}).catch((error) => {
-			console.log(error);
-			console.log(error.body);
+			ToastsStore.error(error.response.data.error);
 		});
 	};
 
 	return (
 		<div className="login">
+			<ToastsContainer store={ToastsStore} position={ToastsContainerPosition.TOP_CENTER} />
 			<Form onSubmit={ev => {
 				ev.preventDefault();
 			}}>

--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -4,6 +4,7 @@ import Button from "react-bootstrap/Button";
 import { Link, useHistory } from "react-router-dom";
 import "./login.scss";
 import axios from "axios";
+import { ToastsContainer, ToastsContainerPosition, ToastsStore } from "react-toasts";
 
 export default function Register() {
 	const [email, setEmail] = useState("");
@@ -12,23 +13,35 @@ export default function Register() {
 	const history = useHistory();
 
 	const registerNewUser = () => {
+		if (email === "") {
+			ToastsStore.error("Please provide an email");
+			return
+		} else if (pwd === "") {
+			ToastsStore.error("Please provide an password");
+			return
+		} else if (name === "") {
+			ToastsStore.error("Please provide a name");
+			return
+		}
+
 		const data = {
 			email: email,
 			password: pwd,
 			name: name
 		};
+
 		axios.post("/account/register", data)
 			.then((res) => {
-				console.log(res);
 				history.push("/login");
 			}).catch((error) => {
-			console.log(error);
+			ToastsStore.error(error.response.data.error);
 		});
 	};
 
 
 	return (
 		<div className="register">
+			<ToastsContainer store={ToastsStore} position={ToastsContainerPosition.TOP_CENTER} />
 			<Form onSubmit={ev => {
 				ev.preventDefault();
 			}}>


### PR DESCRIPTION
# Added client side parameter validation & error toasts

If a client side failure is detected, toast and return.

Else, attempt a server request. If server request fails, raise error toast.

## Examples

![image](https://user-images.githubusercontent.com/32029716/137603976-393b24a8-2168-472d-bca8-0216fef47464.png)

![image](https://user-images.githubusercontent.com/32029716/137603979-a1ab2740-ee3e-4dc5-a8bb-94de13ef48a0.png)

![image](https://user-images.githubusercontent.com/32029716/137603982-3449f39c-8c72-4df9-b3fb-da1f2bec5a89.png)

![image](https://user-images.githubusercontent.com/32029716/137603985-ca2c0985-4755-42cf-97cd-8aa86df35943.png)