### PR TITLE
serving static react files through express with npm run deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .idea
 db.sqlite
 db-test.sqlite
+client/build

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "assignment-2---final-project-repository-team-8",
+  "version": "1.0.0",
+  "description": "cs 484 final project",
+  "main": "index.js",
+  "scripts": {
+    "start": "cd server && npm run deploy",
+    "test": "cd server && npm test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UIC-CS484/assignment-2---final-project-repository-team-8.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/UIC-CS484/assignment-2---final-project-repository-team-8/issues"
+  },
+  "homepage": "https://github.com/UIC-CS484/assignment-2---final-project-repository-team-8#readme"
+}

--- a/readme.md
+++ b/readme.md
@@ -5,41 +5,22 @@ Our CS 484 final project.
 ## Table of Contents
 
 - **[Build and Run](#build-and-run)**<br>
-    - [1. Run the Server](#1-run-the-server)
-    - [2. Run the Client](#2-run-the-client)
-    - [3. Use the application](#3-use-the-application)
 - **[Testing](#testing)**<br>
     - [Unit Testing](#unit-testing)
     - [End-to-End Testing](#end-to-end-testing)
+    - [Running the tests](#running-the-tests)
 - **[Team Members](#team-members)**<br>
 - **[Development Tools](#development-tools)**<br>
 
 ## Build and Run
 
-### 1. Run the Server
-
-From the `~/server` directory, run:
+From the root directory, run:
 
 ```
-$ npm install
 $ npm start
 ```
 
-### 2. Run the Client
-
-Client depends on server, be sure to set that up first!
-
-From the `~/client` directory, run:
-
-```
-$ npm install
-$ npm start
-```
-
-### 3. Use the application
-
-Once the client & server are running, you can navigate to [http://localhost:3000/](http://localhost:3000/) to use the
-application.
+Once the server is running, you can navigate to [http://localhost:8080/](http://localhost:8080/) to use the application.
 
 ## Testing
 
@@ -61,7 +42,7 @@ succeed. For example:
 
 ### Running the tests
 
-To run the tests, navigate to `~/server` and execute
+To run the tests, execute the following from the root directory:
 
 ```
 $ npm test

--- a/server/package.json
+++ b/server/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
+    "deploy": "npm install && cd ../client && npm install && npm run build && cd ../server && nodemon node server.js",
     "start": "nodemon node server.js",
     "test": "jest --watchAll --detectOpenHandles"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ const express = require("express");
 const session = require("express-session");
 const cookieParser = require("cookie-parser");
 const bcrypt = require("bcrypt");
+const path = require("path");
 const passport = require("passport");
 const StatusCodes = require("http-status-codes").StatusCodes;
 const validRegistrationParameters = require("./routes/registration");
@@ -23,10 +24,14 @@ app.use(
 		saveUninitialized: true
 	})
 );
+
 app.use(cookieParser("secretcode"));
 app.use(passport.initialize());
 app.use(passport.session());
 require("./passportConf")(passport);
+
+app.use(express.static(path.resolve(__dirname, "../client/build")));
+
 
 app.listen(port, () => {
 	console.log("Server running on port " + port);


### PR DESCRIPTION
# Serve react static files through express

With this PR, we are able to **serve our react files through express** -- this results in needing only one process to run the application. 

I've added scripts for the root repository that alias to scripts in the server and client folders for convenience.

## Example

You'll see that we access the application through `localhost:8080` which is the port that express uses. Further, you can see API requests being made to validate the password.

![image](https://user-images.githubusercontent.com/32029716/137607720-30ad6668-5350-4a54-b517-e0a4bc35dbab.png)
