### PR TITLE
Add JWT authentication to frontend and backend

### DIFF
--- a/client/src/Common.js
+++ b/client/src/Common.js
@@ -5,10 +5,17 @@ const routes = {
 };
 
 const errors = {
-    NAME: "Please provide a name",
+	NAME: "Please provide a name",
 	EMAIL: "Please provide an email",
 	PASSWORD: "Please provide an password"
-}
+};
 
+const constants = {
+	TOKEN: "token",
+	SECRET: "Hello, world!",
+	EMPTY: ""
+};
+
+module.exports.constants = constants;
 module.exports.errors = errors;
 module.exports.routes = routes;

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -3,6 +3,9 @@ import "./login.scss";
 import { Link, useHistory } from "react-router-dom";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
+import axios from "axios";
+import { constants } from "../Common";
+import { ToastsStore } from "react-toasts";
 
 
 export default function Home() {
@@ -15,7 +18,15 @@ export default function Home() {
 	};
 
 	const submitTweet = () => {
-		console.log(tweet);
+		const token = localStorage.getItem(constants.TOKEN);
+		// TODO: replace this with a post to /tweet, then remove /protected-hello
+		axios.get("/protected-hello", { headers: { "Authorization": `Bearer ${token}` } })
+			.then((res) => {
+				console.log(res);
+			}).catch((error) => {
+			console.log(error);
+			ToastsStore.error(error.response.data.error);
+		});
 	};
 
 	return (

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -2,22 +2,21 @@ import React, { useState } from "react";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
 import { Link, useHistory } from "react-router-dom";
+import { constants, errors, routes } from "../Common";
 import "./login.scss";
 import axios from "axios";
 import { ToastsContainer, ToastsContainerPosition, ToastsStore } from "react-toasts";
-import { errors, routes } from "../Common";
 
 export default function Login() {
 	const [email, setEmail] = useState("");
 	const [pwd, setPwd] = useState("");
 	const history = useHistory();
-	// const [isAuth, setIsAuth] = useState();
 
 	const login = () => {
-		if (email === "") {
+		if (email === constants.EMPTY) {
 			ToastsStore.error(errors.EMAIL);
 			return;
-		} else if (pwd === "") {
+		} else if (pwd === constants.EMPTY) {
 			ToastsStore.error(errors.PASSWORD);
 			return;
 		}
@@ -29,8 +28,7 @@ export default function Login() {
 
 		axios.post(routes.LOGIN, data)
 			.then((res) => {
-				// setIsAuth(res.data);
-				localStorage.setItem("isAuth", res);
+				localStorage.setItem(constants.TOKEN, res.data.token);
 				history.push("/home");
 			}).catch((error) => {
 			ToastsStore.error(error.response.data.error);

--- a/client/src/components/ProtectedRoute.js
+++ b/client/src/components/ProtectedRoute.js
@@ -1,11 +1,12 @@
 import React, { Component } from "react";
 import { Redirect, Route } from "react-router-dom";
+import { constants } from "../Common";
 
 const ProtectedRoute = ({ component: Component, ...rest }) => {
 	return (
 		<Route {...rest}
 			   render={props => {
-				   if (localStorage.getItem("isAuth")) {
+				   if (localStorage.getItem(constants.TOKEN)) {
 					   return <Component {...rest}{...props} />;
 				   } else {
 					   return < Redirect to={

--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -5,7 +5,7 @@ import { Link, useHistory } from "react-router-dom";
 import "./login.scss";
 import axios from "axios";
 import { ToastsContainer, ToastsContainerPosition, ToastsStore } from "react-toasts";
-import { errors, routes } from "../Common";
+import { constants, errors, routes } from "../Common";
 
 export default function Register() {
 	const [email, setEmail] = useState("");
@@ -14,13 +14,13 @@ export default function Register() {
 	const history = useHistory();
 
 	const registerNewUser = () => {
-		if (email === "") {
+		if (email === constants.EMPTY) {
 			ToastsStore.error(errors.EMAIL);
 			return;
-		} else if (pwd === "") {
+		} else if (pwd === constants.EMPTY) {
 			ToastsStore.error(errors.PASSWORD);
 			return;
-		} else if (name === "") {
+		} else if (name === constants.EMPTY) {
 			ToastsStore.error(errors.NAME);
 			return;
 		}

--- a/server/common.js
+++ b/server/common.js
@@ -32,6 +32,9 @@ const routes = {
 	ACCOUNT: "/account"
 };
 
+const SECRET = "Hello, world!";
+
+module.exports.SECRET = SECRET;
 module.exports.routes = routes;
 module.exports.query = query;
 module.exports.errors = errors;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4308,6 +4308,15 @@
         "pause": "0.0.1"
       }
     },
+    "passport-jwt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
+      "requires": {
+        "jsonwebtoken": "^8.2.0",
+        "passport-strategy": "^1.0.0"
+      }
+    },
     "passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "http-status-codes": "^2.1.4",
     "jsonwebtoken": "^8.5.1",
     "passport": "^0.5.0",
+    "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",
     "sqlite3": "^5.0.2"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -6,20 +6,21 @@ const path = require("path");
 const passport = require("passport");
 const StatusCodes = require("http-status-codes").StatusCodes;
 const validRegistrationParameters = require("./routes/registration");
-const {messages, errors, query, routes} = require("./common");
+const { messages, errors, query, routes, SECRET } = require("./common");
+const jwt = require("jsonwebtoken");
 const app = express();
 const saltRounds = 10;
 const port = process.env.NODE_ENV === "test" ? 8081 : 8080;
 const db = require("./database.js").db;
 
 app.use(express.json());
-app.use(express.urlencoded({extended: true}));
+app.use(express.urlencoded({ extended: true }));
 app.use(
-    session({
-        secret: "secretcode",
-        resave: true,
-        saveUninitialized: true
-    })
+	session({
+		secret: "secretcode",
+		resave: true,
+		saveUninitialized: true
+	})
 );
 
 app.use(cookieParser("secretcode"));
@@ -30,88 +31,97 @@ require("./passportConf")(passport);
 // app.use(express.static(path.resolve(__dirname, "../client/build")));
 
 app.listen(port, () => {
-    console.log("Server running on port " + port);
+	console.log("Server running on port " + port);
 });
 
 app.post(routes.REGISTER, async (req, res) => {
-    const [ok, reason] = validRegistrationParameters(req.body.name, req.body.email, req.body.password);
-    if (!ok) {
-        console.log(reason);
-        res.status(StatusCodes.BAD_REQUEST).json({error: reason});
-        return;
-    }
+	const [ok, reason] = validRegistrationParameters(req.body.name, req.body.email, req.body.password);
+	if (!ok) {
+		console.log(reason);
+		res.status(StatusCodes.BAD_REQUEST).json({ error: reason });
+		return;
+	}
 
-    bcrypt.hash(req.body.password, saltRounds, function (hashErr, hash) {
-        if (hashErr) {
-            res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({message: messages.REGISTRATION_FAILED});
-            return;
-        }
+	bcrypt.hash(req.body.password, saltRounds, function(hashErr, hash) {
+		if (hashErr) {
+			res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: messages.REGISTRATION_FAILED });
+			return;
+		}
 
-        const params = [req.body.name, req.body.email, hash];
-        db.run(query.INSERT_ACCOUNT, params, (dbErr, row) => {
-            if (dbErr) {
-                res.status(StatusCodes.CONFLICT).json({error: messages.EMAIL_ALREADY_EXISTS});
-            } else {
-                res.status(StatusCodes.OK).json({message: messages.REGISTRATION_SUCCEEDED});
-            }
-        });
-    });
+		const params = [req.body.name, req.body.email, hash];
+		db.run(query.INSERT_ACCOUNT, params, (dbErr, row) => {
+			if (dbErr) {
+				res.status(StatusCodes.CONFLICT).json({ error: messages.EMAIL_ALREADY_EXISTS });
+			} else {
+				res.status(StatusCodes.OK).json({ message: messages.REGISTRATION_SUCCEEDED });
+			}
+		});
+	});
 });
 
 
 app.post(routes.LOGIN, async (req, res, next) => {
-    passport.authenticate("local", (err, user, info) => {
-        if (err) {
-            let status, msg;
-            switch (err) {
-                case errors.USER_NOT_FOUND:
-                    status = StatusCodes.NOT_FOUND
-                    msg = messages.USER_NOT_FOUND
-                    break;
-                case errors.INCORRECT_PASSWORD:
-                    status = StatusCodes.UNAUTHORIZED
-                    msg = messages.INCORRECT_PASSWORD
-                    break;
-                default:
-                    status = StatusCodes.INTERNAL_SERVER_ERROR
-                    msg = messages.UNEXPECTED_ERROR
-            }
-            res.status(status).json({error: msg});
-        } else if (!user) {
-            res.status(StatusCodes.NOT_FOUND).json({error: messages.USER_NOT_FOUND});
-        } else {
-            req.logIn(user, (err) => {
-                if (err) {
-                    res.status(StatusCodes.UNAUTHORIZED).json({error: messages.LOGIN_FAILED});
-                } else {
-                    res.status(StatusCodes.OK).json({message: messages.LOGIN_SUCCEEDED});
-                }
-            });
-        }
-    })(req, res, next);
+	passport.authenticate("local", (err, user, info) => {
+		if (err) {
+			let status, msg;
+			switch (err) {
+				case errors.USER_NOT_FOUND:
+					status = StatusCodes.NOT_FOUND;
+					msg = messages.USER_NOT_FOUND;
+					break;
+				case errors.INCORRECT_PASSWORD:
+					status = StatusCodes.UNAUTHORIZED;
+					msg = messages.INCORRECT_PASSWORD;
+					break;
+				default:
+					status = StatusCodes.INTERNAL_SERVER_ERROR;
+					msg = messages.UNEXPECTED_ERROR;
+			}
+			res.status(status).json({ error: msg });
+		} else if (!user) {
+			res.status(StatusCodes.NOT_FOUND).json({ error: messages.USER_NOT_FOUND });
+		} else {
+			req.logIn(user, (err) => {
+				if (err) {
+					res.status(StatusCodes.UNAUTHORIZED).json({ error: messages.LOGIN_FAILED });
+				} else {
+					const token = jwt.sign({ user: user.email }, SECRET);
+					console.log(token);
+					res.status(StatusCodes.OK).json({ message: messages.LOGIN_SUCCEEDED, token });
+				}
+			});
+		}
+	})(req, res, next);
 });
 
 app.get(routes.ACCOUNT, (req, res) => {
-    if (!req.query.email) {
-        res.status(StatusCodes.BAD_REQUEST).json({error: messages.BAD_REQUEST});
-    }
+	if (!req.query.email) {
+		res.status(StatusCodes.BAD_REQUEST).json({ error: messages.BAD_REQUEST });
+	}
 
-    const params = [req.query.email];
-    db.get(query.GET_ACCOUNT, params, function (err, row) {
-        if (err) {
-            res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({error: err.message});
-            return console.error(err);
-        }
+	const params = [req.query.email];
+	db.get(query.GET_ACCOUNT, params, function(err, row) {
+		if (err) {
+			res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: err.message });
+			return console.error(err);
+		}
 
-        if (row) {
-            res.status(StatusCodes.OK).json(row);
-        } else {
-            res.status(StatusCodes.NOT_FOUND).json({
-                error: messages.USER_NOT_FOUND
-            });
-        }
-    });
+		if (row) {
+			res.status(StatusCodes.OK).json(row);
+		} else {
+			res.status(StatusCodes.NOT_FOUND).json({
+				error: messages.USER_NOT_FOUND
+			});
+		}
+	});
 });
+
+
+app.get("/protected-hello", passport.authenticate("jwt", { session: false }),
+	function(req, res) {
+		res.status(StatusCodes.OK).json({ message: "Hello World!" });
+	}
+);
 
 module.exports.app = app;
 module.exports.routes = routes;


### PR DESCRIPTION
## In this commit:
- Added a tweet button that sends GET requests to `/protected-hello` using the logged-in user's JWT.
- Added passport JwtStrategy to authenticate requests with JWTs
- Added a dummy endpoint `/protected-hello` to show an example of functionality
- Added dependencies to support JWTs in our application

## Why
To begin implementing endpoint protection with JWTs

## What is next?
Adding a `/tweet` POST endpoint to send tweets to. Tweets should only be accepted if the JWT is valid. A secret is used to encrypt and decrypt the JWT.

🤑

![image](https://user-images.githubusercontent.com/32029716/138607856-004c2a5a-a7cf-4078-ab97-a744b0a29272.png)



