### PR TITLE
insert tweet without refreshing

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -35,7 +35,13 @@ class Home extends React.Component {
 			};
 			axios.post(routes.TWEET, data, { headers: { "Authorization": `Bearer ${token}` } })
 				.then((res) => {
-					// TODO: put this tweet into the user's feed on homepage
+					const tt = {
+						email: localStorage.getItem(constants.EMAIL),
+						tweet: this.tweet,
+						timestamp: new Date().toDateString()
+					};
+					console.log(tt);
+					this.tweets.unshift(tt);
 					this.forceUpdate();
 				}).catch((error) => {
 				ToastsStore.error(error.response.data.error);

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -36,6 +36,7 @@ class Home extends React.Component {
 			axios.post(routes.TWEET, data, { headers: { "Authorization": `Bearer ${token}` } })
 				.then((res) => {
 					const tt = {
+						name: localStorage.getItem(constants.NAME),
 						email: localStorage.getItem(constants.EMAIL),
 						tweet: this.tweet,
 						timestamp: new Date().toDateString()

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -40,7 +40,6 @@ class Home extends React.Component {
 						tweet: this.tweet,
 						timestamp: new Date().toDateString()
 					};
-					console.log(tt);
 					this.tweets.unshift(tt);
 					this.forceUpdate();
 				}).catch((error) => {

--- a/client/src/components/Tweet.js
+++ b/client/src/components/Tweet.js
@@ -6,7 +6,7 @@ const Tweet = ({ data }) => {
 		<>
 			<ul>
 				<li>
-					{data.email} on {date}:
+					{data.name} on {date}:
 				</li>
 				<li>
 					<b> {data.tweet}</b>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,5 @@
 {
   "name": "assignment-2---final-project-repository-team-8",
   "version": "1.0.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "assignment-2---final-project-repository-team-8",
-      "version": "1.0.0",
-      "license": "ISC"
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/server/common.js
+++ b/server/common.js
@@ -23,8 +23,12 @@ const errors = {
 const query = {
 	GET_ACCOUNT: "SELECT * from user WHERE email = ?",
 	GET_EMAIL: "SELECT email from user WHERE email = ?",
-	GET_TWEETS: "SELECT * from tweets WHERE email = ? ORDER BY timestamp DESC",
-	GET_ALL_TWEETS: "SELECT * from tweets ORDER BY timestamp DESC LIMIT 25",
+
+
+	GET_TWEETS: "SELECT user.email, name, tweet, timestamp from tweets join user on tweets.email = user.email WHERE user.email = ? ORDER BY timestamp DESC",
+	GET_ALL_TWEETS: "SELECT user.email, name, tweet, timestamp from tweets join user on tweets.email = user.email ORDER BY timestamp DESC LIMIT 50",
+
+	
 	GET_PASSWORD: "SELECT password from user WHERE email = ?",
 	INSERT_ACCOUNT: "INSERT INTO user (name, email, password) VALUES (?,?,?)",
 	INSERT_TWEET: "INSERT INTO tweets (email, tweet, timestamp) VALUES (?,?,?)",


### PR DESCRIPTION
uses some client side magic to prepend the most recent tweet to the feed instead of fetching it from server

![image](https://user-images.githubusercontent.com/32029716/139516984-0b1fa43e-7a9b-4526-833d-0d2cc499d403.png)
